### PR TITLE
Add categories to charts ui

### DIFF
--- a/src/main/webapp/analytics.html
+++ b/src/main/webapp/analytics.html
@@ -34,7 +34,6 @@
 
 <!-- Custom -->
 <link rel="stylesheet" href="css/analytics.css" />
-<link rel="stylesheet" href="css/common.css" />
 <script src="js/analytics.js"></script>
 <script src="js/common.js"></script>
 

--- a/src/main/webapp/analytics.html
+++ b/src/main/webapp/analytics.html
@@ -44,8 +44,8 @@
     <div class="col-md-6 pl-3">
       <div id="store-chart" class="chart pl-4"></div>
     </div>
-    <div class="col-md-6 pl-3">
-      <div id="category-chart" class="chart pl-4"></div>
+    <div class="col-md-6 pb-5">
+      <div id="category-chart" class="chart pl-2"></div>
     </div>
   </div>
 </div>

--- a/src/main/webapp/analytics.html
+++ b/src/main/webapp/analytics.html
@@ -34,6 +34,7 @@
 
 <!-- Custom -->
 <link rel="stylesheet" href="css/analytics.css" />
+<link rel="stylesheet" href="css/common.css" />
 <script src="js/analytics.js"></script>
 <script src="js/common.js"></script>
 
@@ -42,7 +43,10 @@
   <h1 class="text-center mt-3">Analytics</h1>
   <div class="row d-flex justify-content-center">
     <div class="col-md-6 pl-3">
-      <div id="stores-chart" class="chart pl-4"></div>
+      <div id="store-chart" class="chart pl-4"></div>
+    </div>
+    <div class="col-md-6 pl-3">
+      <div id="category-chart" class="chart pl-4"></div>
     </div>
   </div>
 </div>

--- a/src/main/webapp/js/analytics.js
+++ b/src/main/webapp/js/analytics.js
@@ -40,7 +40,7 @@ function handleStoreChart(analytics) {
   storeData.addColumn('string', 'Store');
   storeData.addColumn('number', 'Total');
 
-  for (const [store, total] of Object.entries(analytics[0])) {
+  for (const [store, total] of Object.entries(analytics.storeAnalytics)) {
     storeData.addRow([capitalizeFirstLetters(store), total]);
   }
 
@@ -57,7 +57,7 @@ function handleCategoryChart(analytics) {
   categoryData.addColumn('string', 'Category');
   categoryData.addColumn('number', 'Total');
 
-  for (const [store, total] of Object.entries(analytics[1])) {
+  for (const [store, total] of Object.entries(analytics.categoryAnalytics)) {
     categoryData.addRow([capitalizeFirstLetters(store), total]);
   }
 

--- a/src/main/webapp/js/analytics.js
+++ b/src/main/webapp/js/analytics.js
@@ -26,8 +26,6 @@ async function computeChartAnalytics() {
   const response = await fetch('/compute-analytics');
   const analytics = await response.json();
 
-  console.log(analytics);
-
   handleStoreChart(analytics);
   handleCategoryChart(analytics);
 }

--- a/src/main/webapp/js/analytics.js
+++ b/src/main/webapp/js/analytics.js
@@ -1,51 +1,186 @@
-// Copyright 2019 Google LLC
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// // Copyright 2019 Google LLC
+// //
+// // Licensed under the Apache License, Version 2.0 (the "License");
+// // you may not use this file except in compliance with the License.
+// // You may obtain a copy of the License at
+// //
+// //     https://www.apache.org/licenses/LICENSE-2.0
+// //
+// // Unless required by applicable law or agreed to in writing, software
+// // distributed under the License is distributed on an "AS IS" BASIS,
+// // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// // See the License for the specific language governing permissions and
+// // limitations under the License.
 
-/* global capitalizeFirstLetters */
+// /* global capitalizeFirstLetters */
+
+// /** Sets callbacks for Google Charts instance. */
+// google.charts.load('current', {'packages': ['corechart']});
+// google.charts.setOnLoadCallback(computeChartAnalytics);
+
+// let storeData;
+// let categoryData;
+
+// /** Computes and populates DataTable with analytics for both charts. */
+// async function computeChartAnalytics() {
+//   const response = await fetch('/compute-analytics');
+//   const analytics = await response.json();
+
+//   handleStoreChart(analytics);
+//   handleCategoryChart(analytics);
+// }
+
+// /**
+//  * Populates DataTable with store data and passes that to draw method.
+//  * @param {Array} analytics First entry is store data, second is category.
+//  */
+// function handleStoreChart(analytics) {
+//   storeData = new google.visualization.DataTable();
+
+//   storeData.addColumn('string', 'Store');
+//   storeData.addColumn('number', 'Total');
+
+//   for (const [store, total] of Object.entries(analytics[0])) {
+//     storeData.addRow([store, total]);
+//   }
+
+//   drawStoreChart(storeData);
+// }
+
+// /**
+//  * Populates DataTable with category data and passes that to draw method.
+//  * @param {Array} analytics First entry is store data, second is category.
+//  */
+// function handleCategoryChart(analytics) {
+//   categoryData = new google.visualization.DataTable();
+
+//   categoryData.addColumn('string', 'Category');
+//   categoryData.addColumn('number', 'Total');
+
+//   for (const [store, total] of Object.entries(analytics[1])) {
+//     categoryData.addRow([store, total]);
+//   }
+
+//   drawCategoryChart(categoryData);
+// }
+
+// /**
+//  * Intializes and draws store chart onto DOM.
+//  * @param {DataTable} data Table with stores and their totals.
+//  */
+// function drawStoreChart(data) {
+//   // Get parent div dimensions to make chart fit the appropriate space.
+//   const chartWidth =
+//       document.getElementById('store-chart').getBoundingClientRect().width;
+//   const chartHeight =
+//       document.getElementById('store-chart').getBoundingClientRect().height;
+
+//   const options = {
+//     title: 'Spending habits by store',
+//     pieHole: 0.3,
+//     width: chartWidth,
+//     legend: {alignment: 'center'},
+//     chartArea: {width: chartWidth, height: chartHeight * 0.6},
+//     sliceVisibilityThreshold: .03,
+//   };
+
+//   const chart =
+//       new google.visualization.PieChart(document.getElementById('store-chart'));
+//   chart.draw(data, options);
+// }
+
+// /**
+//  * Intializes and draws category chart onto DOM.
+//  * @param {DataTable} data Table with categories and their totals.
+//  */
+// function drawCategoryChart(data) {
+//   // Get parent div dimensions to make chart fit the appropriate space.
+//   const chartWidth =
+//       document.getElementById('category-chart').getBoundingClientRect().width;
+//   const chartHeight =
+//       document.getElementById('category-chart').getBoundingClientRect().height;
+
+//   const options = {
+//     title: 'Spending habits by category',
+//     pieHole: 0.3,
+//     width: chartWidth,
+//     legend: {alignment: 'center'},
+//     chartArea: {width: chartWidth, height: chartHeight * 0.6},
+//     sliceVisibilityThreshold: .03,
+//   };
+
+//   const chart = new google.visualization.PieChart(
+//       document.getElementById('category-chart'));
+//   chart.draw(data, options);
+// }
+
+// /** Handles sizing of chart to be responsive on different screen sizes. */
+// $(window).resize(function() {
+//   drawStoreChart(storeData);
+//   drawCategoryChart(categoryData);
+// });
+
 
 /** Sets callbacks for Google Charts instance. */
 google.charts.load('current', {'packages': ['corechart']});
-google.charts.setOnLoadCallback(computeStoreChartsAnalytics);
+google.charts.setOnLoadCallback(computeChartAnalytics);
 
 let storeData;
+let categoryData;
 
-/** Computes and populates DataTable with analytics for stores chart. */
-async function computeStoreChartsAnalytics() {
+/** Computes and populates DataTables with analytics for both charts. */
+async function computeChartAnalytics() {
   const response = await fetch('/compute-analytics');
   const analytics = await response.json();
 
+  handleStoreChart(analytics);
+  handleCategoryChart(analytics);
+}
+
+/**
+ * Populates DataTable with store data and passes that to draw method.
+ * @param {Array} analytics First entry is store data, second is category.
+ */
+function handleStoreChart(analytics) {
   storeData = new google.visualization.DataTable();
 
   storeData.addColumn('string', 'Store');
   storeData.addColumn('number', 'Total');
 
-  for (const [store, total] of Object.entries(analytics)) {
-    storeData.addRow([capitalizeFirstLetters(store), total]);
+  for (const [store, total] of Object.entries(analytics[0])) {
+    storeData.addRow([store, total]);
   }
 
-  drawStoresChart(storeData);
+  drawStoreChart(storeData);
 }
 
 /**
- * Intializes and draws stores chart onto DOM.
+ * Populates DataTable with category data and passes that to draw method.
+ * @param {Array} analytics First entry is store data, second is category.
+ */
+function handleCategoryChart(analytics) {
+  categoryData = new google.visualization.DataTable();
+
+  categoryData.addColumn('string', 'Category');
+  categoryData.addColumn('number', 'Total');
+
+  for (const [store, total] of Object.entries(analytics[1])) {
+    categoryData.addRow([store, total]);
+  }
+
+  drawCategoryChart(categoryData);
+}
+
+/**
+ * Sets up and draws store chart onto DOM.
  * @param {DataTable} data Table with stores and their totals.
  */
-function drawStoresChart(data) {
+function drawStoreChart(data) {
+  // Get parent div dimensions to make chart fit the appropriate space.
   const chartWidth =
-      document.getElementById('stores-chart').getBoundingClientRect().width;
+      document.getElementById('store-chart').getBoundingClientRect().width;
   const chartHeight =
-      document.getElementById('stores-chart').getBoundingClientRect().height;
+      document.getElementById('store-chart').getBoundingClientRect().height;
 
   const options = {
     title: 'Spending habits by store',
@@ -53,14 +188,41 @@ function drawStoresChart(data) {
     width: chartWidth,
     legend: {alignment: 'center'},
     chartArea: {width: chartWidth, height: chartHeight * 0.6},
+    sliceVisibilityThreshold: .03,
+  };
+
+  const chart =
+      new google.visualization.PieChart(document.getElementById('store-chart'));
+  chart.draw(data, options);
+}
+
+/**
+ * Intializes and draws category chart onto DOM.
+ * @param {DataTable} data Table with categories and their totals.
+ */
+function drawCategoryChart(data) {
+  // Get parent div dimensions to make chart fit the appropriate space.
+  const chartWidth =
+      document.getElementById('category-chart').getBoundingClientRect().width;
+  const chartHeight =
+      document.getElementById('category-chart').getBoundingClientRect().height;
+
+  const options = {
+    title: 'Spending habits by category',
+    pieHole: 0.3,
+    width: chartWidth,
+    legend: {alignment: 'center'},
+    chartArea: {width: chartWidth, height: chartHeight * 0.6},
+    sliceVisibilityThreshold: .03,
   };
 
   const chart = new google.visualization.PieChart(
-      document.getElementById('stores-chart'));
+      document.getElementById('category-chart'));
   chart.draw(data, options);
 }
 
 /** Handles sizing of chart to be responsive on different screen sizes. */
 $(window).resize(function() {
-  drawStoresChart(storeData);
+  drawStoreChart(storeData);
+  drawCategoryChart(categoryData);
 });

--- a/src/main/webapp/js/analytics.js
+++ b/src/main/webapp/js/analytics.js
@@ -1,125 +1,18 @@
-// // Copyright 2019 Google LLC
-// //
-// // Licensed under the Apache License, Version 2.0 (the "License");
-// // you may not use this file except in compliance with the License.
-// // You may obtain a copy of the License at
-// //
-// //     https://www.apache.org/licenses/LICENSE-2.0
-// //
-// // Unless required by applicable law or agreed to in writing, software
-// // distributed under the License is distributed on an "AS IS" BASIS,
-// // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// // See the License for the specific language governing permissions and
-// // limitations under the License.
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
-// /* global capitalizeFirstLetters */
-
-// /** Sets callbacks for Google Charts instance. */
-// google.charts.load('current', {'packages': ['corechart']});
-// google.charts.setOnLoadCallback(computeChartAnalytics);
-
-// let storeData;
-// let categoryData;
-
-// /** Computes and populates DataTable with analytics for both charts. */
-// async function computeChartAnalytics() {
-//   const response = await fetch('/compute-analytics');
-//   const analytics = await response.json();
-
-//   handleStoreChart(analytics);
-//   handleCategoryChart(analytics);
-// }
-
-// /**
-//  * Populates DataTable with store data and passes that to draw method.
-//  * @param {Array} analytics First entry is store data, second is category.
-//  */
-// function handleStoreChart(analytics) {
-//   storeData = new google.visualization.DataTable();
-
-//   storeData.addColumn('string', 'Store');
-//   storeData.addColumn('number', 'Total');
-
-//   for (const [store, total] of Object.entries(analytics[0])) {
-//     storeData.addRow([store, total]);
-//   }
-
-//   drawStoreChart(storeData);
-// }
-
-// /**
-//  * Populates DataTable with category data and passes that to draw method.
-//  * @param {Array} analytics First entry is store data, second is category.
-//  */
-// function handleCategoryChart(analytics) {
-//   categoryData = new google.visualization.DataTable();
-
-//   categoryData.addColumn('string', 'Category');
-//   categoryData.addColumn('number', 'Total');
-
-//   for (const [store, total] of Object.entries(analytics[1])) {
-//     categoryData.addRow([store, total]);
-//   }
-
-//   drawCategoryChart(categoryData);
-// }
-
-// /**
-//  * Intializes and draws store chart onto DOM.
-//  * @param {DataTable} data Table with stores and their totals.
-//  */
-// function drawStoreChart(data) {
-//   // Get parent div dimensions to make chart fit the appropriate space.
-//   const chartWidth =
-//       document.getElementById('store-chart').getBoundingClientRect().width;
-//   const chartHeight =
-//       document.getElementById('store-chart').getBoundingClientRect().height;
-
-//   const options = {
-//     title: 'Spending habits by store',
-//     pieHole: 0.3,
-//     width: chartWidth,
-//     legend: {alignment: 'center'},
-//     chartArea: {width: chartWidth, height: chartHeight * 0.6},
-//     sliceVisibilityThreshold: .03,
-//   };
-
-//   const chart =
-//       new google.visualization.PieChart(document.getElementById('store-chart'));
-//   chart.draw(data, options);
-// }
-
-// /**
-//  * Intializes and draws category chart onto DOM.
-//  * @param {DataTable} data Table with categories and their totals.
-//  */
-// function drawCategoryChart(data) {
-//   // Get parent div dimensions to make chart fit the appropriate space.
-//   const chartWidth =
-//       document.getElementById('category-chart').getBoundingClientRect().width;
-//   const chartHeight =
-//       document.getElementById('category-chart').getBoundingClientRect().height;
-
-//   const options = {
-//     title: 'Spending habits by category',
-//     pieHole: 0.3,
-//     width: chartWidth,
-//     legend: {alignment: 'center'},
-//     chartArea: {width: chartWidth, height: chartHeight * 0.6},
-//     sliceVisibilityThreshold: .03,
-//   };
-
-//   const chart = new google.visualization.PieChart(
-//       document.getElementById('category-chart'));
-//   chart.draw(data, options);
-// }
-
-// /** Handles sizing of chart to be responsive on different screen sizes. */
-// $(window).resize(function() {
-//   drawStoreChart(storeData);
-//   drawCategoryChart(categoryData);
-// });
-
+/* global capitalizeFirstLetters */
 
 /** Sets callbacks for Google Charts instance. */
 google.charts.load('current', {'packages': ['corechart']});
@@ -128,7 +21,7 @@ google.charts.setOnLoadCallback(computeChartAnalytics);
 let storeData;
 let categoryData;
 
-/** Computes and populates DataTables with analytics for both charts. */
+/** Computes and populates DataTable with analytics for both charts. */
 async function computeChartAnalytics() {
   const response = await fetch('/compute-analytics');
   const analytics = await response.json();
@@ -148,7 +41,7 @@ function handleStoreChart(analytics) {
   storeData.addColumn('number', 'Total');
 
   for (const [store, total] of Object.entries(analytics[0])) {
-    storeData.addRow([store, total]);
+    storeData.addRow([capitalizeFirstLetters(store), total]);
   }
 
   drawStoreChart(storeData);
@@ -165,14 +58,14 @@ function handleCategoryChart(analytics) {
   categoryData.addColumn('number', 'Total');
 
   for (const [store, total] of Object.entries(analytics[1])) {
-    categoryData.addRow([store, total]);
+    categoryData.addRow([capitalizeFirstLetters(store), total]);
   }
 
   drawCategoryChart(categoryData);
 }
 
 /**
- * Sets up and draws store chart onto DOM.
+ * Intializes and draws store chart onto DOM.
  * @param {DataTable} data Table with stores and their totals.
  */
 function drawStoreChart(data) {

--- a/src/main/webapp/js/analytics.js
+++ b/src/main/webapp/js/analytics.js
@@ -51,7 +51,7 @@ function handleStoreChart(analytics) {
 
 /**
  * Populates DataTable with category data and passes that to draw method.
- * @param {Array} analytics First entry is store data, second is category.
+ * @param {JSON} analytics
  */
 function handleCategoryChart(analytics) {
   categoryData = new google.visualization.DataTable();

--- a/src/main/webapp/js/analytics.js
+++ b/src/main/webapp/js/analytics.js
@@ -26,6 +26,8 @@ async function computeChartAnalytics() {
   const response = await fetch('/compute-analytics');
   const analytics = await response.json();
 
+  console.log(analytics);
+
   handleStoreChart(analytics);
   handleCategoryChart(analytics);
 }
@@ -84,6 +86,7 @@ function drawStoreChart(data) {
     sliceVisibilityThreshold: .03,
   };
 
+  data.sort({column: 1, desc: true});
   const chart =
       new google.visualization.PieChart(document.getElementById('store-chart'));
   chart.draw(data, options);
@@ -97,19 +100,26 @@ function drawCategoryChart(data) {
   // Get parent div dimensions to make chart fit the appropriate space.
   const chartWidth =
       document.getElementById('category-chart').getBoundingClientRect().width;
-  const chartHeight =
-      document.getElementById('category-chart').getBoundingClientRect().height;
 
   const options = {
-    title: 'Spending habits by category',
-    pieHole: 0.3,
+    title: 'Spending habits by category (top 10)',
+    vAxis: {title: 'Total ($)'},
+    legend: {position: 'none'},
     width: chartWidth,
-    legend: {alignment: 'center'},
-    chartArea: {width: chartWidth, height: chartHeight * 0.6},
-    sliceVisibilityThreshold: .03,
+    hAxis: {
+      title: 'Category',
+      showTextEvery: 1,
+      slantedText: true,
+      slantedTextAngle: 60,
+      viewWindow: {max: 10},
+    },
+    chartArea: {width: chartWidth * 0.75},
   };
 
-  const chart = new google.visualization.PieChart(
+  // Sort by price so we can easily find the top 10 categories.
+  data.sort({column: 1, desc: true});
+
+  const chart = new google.visualization.ColumnChart(
       document.getElementById('category-chart'));
   chart.draw(data, options);
 }

--- a/src/main/webapp/js/analytics.js
+++ b/src/main/webapp/js/analytics.js
@@ -59,8 +59,8 @@ function handleCategoryChart(analytics) {
   categoryData.addColumn('string', 'Category');
   categoryData.addColumn('number', 'Total');
 
-  for (const [store, total] of Object.entries(analytics.categoryAnalytics)) {
-    categoryData.addRow([capitalizeFirstLetters(store), total]);
+  for (const [category, total] of Object.entries(analytics.categoryAnalytics)) {
+    categoryData.addRow([capitalizeFirstLetters(category), total]);
   }
 
   drawCategoryChart(categoryData);

--- a/src/test/java/TestUtils.java
+++ b/src/test/java/TestUtils.java
@@ -46,18 +46,16 @@ public final class TestUtils {
 
   /** Adds multiple receipts to datastore. */
   public static ImmutableSet<Entity> addTestReceipts(DatastoreService datastore) {
-    ImmutableSet<Entity> entities =
-        ImmutableSet.of(createEntity(/* userId = */ "123", /* timestamp = */ 1045237591000L,
-                            new BlobKey("test"), "img/walmart-receipt.jpg", 26.12, "walmart",
-                            ImmutableSet.of("candy", "drink"), ""),
+    ImmutableSet<Entity> entities = ImmutableSet.of(
+        createEntity(/* userId = */ "123", /* timestamp = */ 1045237591000L, new BlobKey("test"),
+            "img/walmart-receipt.jpg", 26.12, "walmart", ImmutableSet.of("candy", "drink"), ""),
 
-            createEntity(/* userId = */ "123", /* timestamp = */ 1560193140000L,
-                new BlobKey("test"), "img/contoso-receipt.jpg", 14.51, "contoso",
-                ImmutableSet.of("cappuccino", "food"), ""),
+        createEntity(/* userId = */ "123", /* timestamp = */ 1560193140000L, new BlobKey("test"),
+            "img/contoso-receipt.jpg", 14.51, "contoso", ImmutableSet.of("cappuccino", "food"), ""),
 
-            createEntity(/* userId = */ "123", /* timestamp = */ 1491582960000L,
-                new BlobKey("test"), "img/restaurant-receipt.jpeg", 29.01, "main street restaurant",
-                ImmutableSet.of("food"), ""));
+        createEntity(/* userId = */ "123", /* timestamp = */ 1491582960000L, new BlobKey("test"),
+            "img/restaurant-receipt.jpeg", 29.01, "main street restaurant", ImmutableSet.of("food"),
+            ""));
 
     entities.stream().forEach(entity -> datastore.put(entity));
 
@@ -97,7 +95,7 @@ public final class TestUtils {
     when(request.getParameter("max")).thenReturn(maxPrice);
   }
 
-    /** Parses a string containing store analytics into a hashmap representation. */
+  /** Parses a string containing store analytics into a hashmap representation. */
   public static HashMap<String, Double> parseStoreAnalytics(String str) throws IOException {
     String stores = str.substring(str.indexOf("{"), str.indexOf("}") + 1);
     return new ObjectMapper().readValue(stores, HashMap.class);


### PR DESCRIPTION
- Add categories column chart to the UI
- Add an "other" pie slice to handle cases where there are too many stores to reasonably fit on the chart
- Categories chart limited to top 10 categories

![Screenshot 2020-07-28 at 4 30 45 PM](https://user-images.githubusercontent.com/39545994/88724539-4f563680-d0f0-11ea-8b72-2c5d22d3179c.png)

