### PR TITLE
Fix imageUrl parameter in query string.

### DIFF
--- a/src/main/webapp/js/upload.js
+++ b/src/main/webapp/js/upload.js
@@ -84,7 +84,7 @@ async function uploadReceipt(event) {
   const params = new URLSearchParams();
   params.append('id', json.key.id);
   params.append('categories', receipt.categories);
-  params.append('image-url', receipt.imageUrl);
+  params.append('image-url', receipt.imageUrl.value);
   params.append('price', receipt.price);
   params.append('store', receipt.store);
   params.append('timestamp', receipt.timestamp);


### PR DESCRIPTION
Fixes invalid image URL in the query string of the receipt analysis page after redirecting from the upload page. Since imageUrl is now an unindexed property, the string value is accessed through the `.value` property of the JSON object.