### PR TITLE
Add warning for navigating away from the receipt analysis page.

### DIFF
--- a/src/main/webapp/receipt-analysis.html
+++ b/src/main/webapp/receipt-analysis.html
@@ -77,9 +77,9 @@
       <img id="receipt-image" src="-" alt="Receipt image" class="d-block p-2 img-fluid" />
     </div>
 
-    <!-- TODO: Add warning if user has unsaved changes or an incomplete receipt. -->
+    <!-- TODO: Add warning if user has an incomplete receipt. -->
     <div class="my-4 d-flex justify-content-center">
-      <a href="/" class="btn btn-lg btn-info">Return to Home</a>
+      <button href="/" class="btn btn-lg btn-info" type="button" onclick="redirectHome()">Return to Home</button>
     </div>
   </div>
 


### PR DESCRIPTION
If the user makes changes to the receipt fields on the receipt upload page, but does not submit the edit form then they will get a warning message before they can return to the home page.
![analysis](https://user-images.githubusercontent.com/38800607/88832118-563b8280-d19e-11ea-906e-6b1962b61f35.png)
