### PR TITLE
Fix image error on receipt analysis page.

### DIFF
--- a/src/main/webapp/receipt-analysis.html
+++ b/src/main/webapp/receipt-analysis.html
@@ -74,7 +74,7 @@
           <button id="submit-receipt" class="btn btn-outline-info" type="submit">Save Changes</button>
         </div>
       </form>
-      <img id="receipt-image" src="-" alt="Receipt image" class="d-block p-2 img-fluid" />
+      <img id="receipt-image" src="data:," alt="Receipt image" class="d-block p-2 img-fluid" />
     </div>
 
     <!-- TODO: Add warning if user has unsaved changes or an incomplete receipt. -->


### PR DESCRIPTION
Sets the initial `src` attribute of the receipt image on the analysis page to an empty media type before it is set using the query string. Using a `src` of "-" will cause a 404 error and "" will fail linter checks.