### PR TITLE
Add warning for incomplete receipt.

### DIFF
--- a/src/main/webapp/js/upload.js
+++ b/src/main/webapp/js/upload.js
@@ -80,24 +80,7 @@ async function uploadReceipt(event) {
   }
 
   const json = (await response.json());
-  const receipt = json.propertyMap;
-  const params = new URLSearchParams();
-  params.append('id', json.key.id);
-  params.append('image-url', receipt.imageUrl.value);
-
-  // Add fields that were successfully generated.
-  if (receipt.categories.length > 0) {
-    params.append('categories', receipt.categories);
-  }
-  if (receipt.price) {
-    params.append('price', receipt.price);
-  }
-  if (receipt.store) {
-    params.append('store', receipt.store);
-  }
-  if (receipt.timestamp) {
-    params.append('timestamp', receipt.timestamp);
-  }
+  const params = setUrlParameters(json);
 
   // Redirect to the receipt analysis page.
   window.location.href = `/receipt-analysis.html?${params.toString()}`;
@@ -144,6 +127,31 @@ function startLoading() {
 
     loadingBar.set(value + increment);
   }, 20);
+}
+
+/**
+ * Creates URL parameters using the properties of the receipt in the given JSON
+ * response.
+ */
+function setUrlParameters(json) {
+  const receipt = json.propertyMap;
+  const params = new URLSearchParams();
+  params.append('id', json.key.id);
+  params.append('image-url', receipt.imageUrl.value);
+
+  // Add fields that were successfully generated.
+  if (receipt.categories.length > 0) {
+    params.append('categories', receipt.categories);
+  }
+  if (receipt.price) {
+    params.append('price', receipt.price);
+  }
+  if (receipt.store) {
+    params.append('store', receipt.store);
+  }
+  if (receipt.timestamp) {
+    params.append('timestamp', receipt.timestamp);
+  }
 }
 
 /**

--- a/src/main/webapp/js/upload.js
+++ b/src/main/webapp/js/upload.js
@@ -83,11 +83,21 @@ async function uploadReceipt(event) {
   const receipt = json.propertyMap;
   const params = new URLSearchParams();
   params.append('id', json.key.id);
-  params.append('categories', receipt.categories);
   params.append('image-url', receipt.imageUrl.value);
-  params.append('price', receipt.price);
-  params.append('store', receipt.store);
-  params.append('timestamp', receipt.timestamp);
+
+  // Add fields that were successfully generated.
+  if (receipt.categories) {
+    params.append('categories', receipt.categories);
+  }
+  if (receipt.price) {
+    params.append('price', receipt.price);
+  }
+  if (receipt.store) {
+    params.append('store', receipt.store);
+  }
+  if (receipt.timestamp) {
+    params.append('timestamp', receipt.timestamp);
+  }
 
   // Redirect to the receipt analysis page.
   window.location.href = `/receipt-analysis.html?${params.toString()}`;

--- a/src/main/webapp/js/upload.js
+++ b/src/main/webapp/js/upload.js
@@ -86,7 +86,7 @@ async function uploadReceipt(event) {
   params.append('image-url', receipt.imageUrl.value);
 
   // Add fields that were successfully generated.
-  if (receipt.categories) {
+  if (receipt.categories.length > 0) {
     params.append('categories', receipt.categories);
   }
   if (receipt.price) {


### PR DESCRIPTION
- Fixes issue with fields showing up as "Undefined" on receipt analysis page
- Sets the default value for the date input to the current date
- Removes fields that were not detected from the receipt analysis page query string
- Ensures that all fields have been set before the user can leave the receipt analysis page