### PR TITLE
Handle receipt analysis errors.

### DIFF
--- a/src/main/java/data/AnalysisResults.java
+++ b/src/main/java/data/AnalysisResults.java
@@ -22,20 +22,20 @@ import java.util.Set;
  * Object for holding the analysis results served by ReceiptAnalysisServlet.
  */
 public class AnalysisResults {
-  private final String rawText;
+  private final Optional<String> rawText;
   private final ImmutableSet<String> categories;
   private final Optional<String> store;
   private final Optional<Long> timestamp;
 
   private AnalysisResults(
-      String rawText, Set<String> categories, Optional<String> store, Optional<Long> timestamp) {
+      Optional<String> rawText, Set<String> categories, Optional<String> store) {
     this.rawText = rawText;
     this.categories = ImmutableSet.copyOf(categories);
     this.store = store;
     this.timestamp = timestamp;
   }
 
-  public String getRawText() {
+  public Optional<String> getRawText() {
     return rawText;
   }
 
@@ -52,17 +52,18 @@ public class AnalysisResults {
   }
 
   public static class Builder {
-    private final String rawText;
-    private ImmutableSet<String> categories;
+    private Optional<String> rawText = Optional.empty();
+    private ImmutableSet<String> categories = ImmutableSet.of();
     private Optional<String> store = Optional.empty();
     private Optional<Long> timestamp = Optional.empty();
 
-    public Builder(String rawText) {
-      this.rawText = rawText;
+    public Optional<String> getRawText() {
+      return rawText;
     }
 
-    public String getRawText() {
-      return rawText;
+    public Builder setRawText(String rawText) {
+      this.rawText = Optional.of(rawText);
+      return this;
     }
 
     public Builder setCategories(Set<String> categories) {

--- a/src/main/java/data/AnalysisResults.java
+++ b/src/main/java/data/AnalysisResults.java
@@ -28,7 +28,7 @@ public class AnalysisResults {
   private final Optional<Long> timestamp;
 
   private AnalysisResults(
-      Optional<String> rawText, Set<String> categories, Optional<String> store) {
+      Optional<String> rawText, Set<String> categories, Optional<String> store, Optional<Long> timestamp) {
     this.rawText = rawText;
     this.categories = ImmutableSet.copyOf(categories);
     this.store = store;

--- a/src/main/java/data/AnalysisResults.java
+++ b/src/main/java/data/AnalysisResults.java
@@ -27,8 +27,8 @@ public class AnalysisResults {
   private final Optional<String> store;
   private final Optional<Long> timestamp;
 
-  private AnalysisResults(
-      Optional<String> rawText, Set<String> categories, Optional<String> store, Optional<Long> timestamp) {
+  private AnalysisResults(Optional<String> rawText, Set<String> categories, Optional<String> store,
+      Optional<Long> timestamp) {
     this.rawText = rawText;
     this.categories = ImmutableSet.copyOf(categories);
     this.store = store;

--- a/src/main/java/servlets/ReceiptAnalysis.java
+++ b/src/main/java/servlets/ReceiptAnalysis.java
@@ -68,16 +68,14 @@ public class ReceiptAnalysis {
       Pattern.compile("\\d?\\d([/-])\\d?\\d\\1\\d{2}(\\d{2})?");
 
   /** Returns the text and categorization of the image at the requested URL. */
-  public static AnalysisResults analyzeImageAt(URL url)
-      throws IOException, ReceiptAnalysisException {
+  public static AnalysisResults analyzeImageAt(URL url) throws IOException {
     ByteString imageBytes = readImageBytes(url);
 
     return analyzeImage(imageBytes);
   }
 
   /** Returns the text and categorization of the image at the requested blob key. */
-  public static AnalysisResults analyzeImageAt(BlobKey blobKey)
-      throws IOException, ReceiptAnalysisException {
+  public static AnalysisResults analyzeImageAt(BlobKey blobKey) throws IOException {
     ByteString imageBytes = readImageBytes(blobKey);
 
     return analyzeImage(imageBytes);
@@ -120,21 +118,24 @@ public class ReceiptAnalysis {
   }
 
   /** Analyzes the image represented by the given ByteString. */
-  private static AnalysisResults analyzeImage(ByteString imageBytes)
-      throws IOException, ReceiptAnalysisException {
+  private static AnalysisResults analyzeImage(ByteString imageBytes) throws IOException {
     AnalysisResults.Builder analysisBuilder = retrieveText(imageBytes);
-    ImmutableSet<String> categories = categorizeText(analysisBuilder.getRawText());
 
-    Stream<String> tokens = getTokensFromRawText(analysisBuilder.getRawText());
-    checkForParsableDate(analysisBuilder, tokens);
+    // Generate categories and parse date if text was extracted.
+    if (analysisBuilder.getRawText().isPresent()) {
+      ImmutableSet<String> categories = categorizeText(analysisBuilder.getRawText().get());
+      analysisBuilder.setCategories(categories);
 
-    return analysisBuilder.setCategories(categories).build();
+      Stream<String> tokens = getTokensFromRawText(analysisBuilder.getRawText().get());
+      checkForParsableDate(analysisBuilder, tokens);
+    }
+
+    return analysisBuilder.build();
   }
 
   /** Detects and retrieves text and store logo in the provided image. */
-  private static AnalysisResults.Builder retrieveText(ByteString imageBytes)
-      throws IOException, ReceiptAnalysisException {
-    AnalysisResults.Builder analysisBuilder;
+  private static AnalysisResults.Builder retrieveText(ByteString imageBytes) throws IOException {
+    AnalysisResults.Builder analysisBuilder = new AnalysisResults.Builder();
 
     Image image = Image.newBuilder().setContent(imageBytes).build();
     ImmutableList<Feature> features =
@@ -148,24 +149,23 @@ public class ReceiptAnalysis {
       BatchAnnotateImagesResponse batchResponse = client.batchAnnotateImages(requests);
 
       if (batchResponse.getResponsesList().isEmpty()) {
-        throw new ReceiptAnalysisException("Received empty batch image annotation response.");
+        return analysisBuilder;
       }
 
       AnnotateImageResponse response = Iterables.getOnlyElement(batchResponse.getResponsesList());
 
       if (response.hasError()) {
-        throw new ReceiptAnalysisException("Received image annotation response with error.");
-      } else if (response.getTextAnnotationsList().isEmpty()) {
-        // TODO: Handle case with no raw text by depending on user-assigned categories.
-        throw new ReceiptAnalysisException(
-            "Received image annotation response without text annotations.");
+        return analysisBuilder;
       }
 
-      // First element has the entire raw text from the image.
-      EntityAnnotation textAnnotation = response.getTextAnnotationsList().get(0);
+      // Add extracted raw text to builder.
+      if (!response.getTextAnnotationsList().isEmpty()) {
+        // First element has the entire raw text from the image.
+        EntityAnnotation textAnnotation = response.getTextAnnotationsList().get(0);
 
-      String rawText = textAnnotation.getDescription();
-      analysisBuilder = new AnalysisResults.Builder(rawText);
+        String rawText = textAnnotation.getDescription();
+        analysisBuilder.setRawText(rawText);
+      }
 
       // If a logo was detected with a confidence above the threshold, use it to set the store.
       if (!response.getLogoAnnotationsList().isEmpty()
@@ -175,15 +175,15 @@ public class ReceiptAnalysis {
         analysisBuilder.setStore(store);
       }
     } catch (ApiException e) {
-      throw new ReceiptAnalysisException("Image annotation request failed.", e);
+      // Return default builder if image annotation request failed.
+      return analysisBuilder;
     }
 
     return analysisBuilder;
   }
 
   /** Generates categories for the provided text. */
-  private static ImmutableSet<String> categorizeText(String text)
-      throws IOException, ReceiptAnalysisException {
+  private static ImmutableSet<String> categorizeText(String text) throws IOException {
     ImmutableSet<String> categories = ImmutableSet.of();
 
     try (LanguageServiceClient client = LanguageServiceClient.create()) {
@@ -197,7 +197,8 @@ public class ReceiptAnalysis {
                        .flatMap(ReceiptAnalysis::parseCategory)
                        .collect(ImmutableSet.toImmutableSet());
     } catch (ApiException e) {
-      throw new ReceiptAnalysisException("Classify text request failed.", e);
+      // Return empty set if classification request failed.
+      return categories;
     }
 
     return categories;
@@ -289,10 +290,6 @@ public class ReceiptAnalysis {
   public static class ReceiptAnalysisException extends Exception {
     public ReceiptAnalysisException(String errorMessage, Throwable err) {
       super(errorMessage, err);
-    }
-
-    public ReceiptAnalysisException(String errorMessage) {
-      super(errorMessage);
     }
   }
 }

--- a/src/main/java/servlets/ReceiptAnalysisServlet.java
+++ b/src/main/java/servlets/ReceiptAnalysisServlet.java
@@ -16,7 +16,6 @@ package com.google.sps.servlets;
 
 import com.google.gson.Gson;
 import com.google.sps.data.AnalysisResults;
-import com.google.sps.servlets.ReceiptAnalysis.ReceiptAnalysisException;
 import java.io.IOException;
 import java.net.URL;
 import javax.servlet.annotation.WebServlet;
@@ -41,13 +40,7 @@ public class ReceiptAnalysisServlet extends HttpServlet {
       return;
     }
 
-    try {
-      results = ReceiptAnalysis.analyzeImageAt(new URL(url));
-    } catch (ReceiptAnalysisException e) {
-      response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
-      response.getWriter().println(e.toString());
-      return;
-    }
+    results = ReceiptAnalysis.analyzeImageAt(new URL(url));
 
     Gson gson = new Gson();
     response.setContentType("application/json;");

--- a/src/main/java/servlets/UploadReceiptServlet.java
+++ b/src/main/java/servlets/UploadReceiptServlet.java
@@ -248,7 +248,8 @@ public class UploadReceiptServlet extends HttpServlet {
     receipt.setProperty("price", FormatUtils.roundPrice(request.getParameter("price")));
 
     // Text objects wrap around a string of unlimited size while strings are limited to 1500 bytes.
-    receipt.setUnindexedProperty("rawText", new Text(results.getRawText()));
+    results.getRawText().ifPresent(
+        rawText -> receipt.setUnindexedProperty("rawText", new Text(rawText)));
     receipt.setProperty(
         "categories", FormatUtils.sanitizeCategories(results.getCategories().stream()));
     // If a logo was detected, set the store name.

--- a/src/test/java/ReceiptAnalysisTest.java
+++ b/src/test/java/ReceiptAnalysisTest.java
@@ -66,17 +66,8 @@ import org.powermock.modules.junit4.PowerMockRunner;
 @PrepareForTest(
     {ImageAnnotatorClient.class, LanguageServiceClient.class, ReceiptAnalysis.class, URL.class})
 public final class ReceiptAnalysisTest {
-  private static final String EMPTY_BATCH_RESPONSE_WARNING =
-      "Received empty batch image annotation response.";
-  private static final String RESPONSE_ERROR_WARNING =
-      "Received image annotation response with error.";
-  private static final String EMPTY_TEXT_ANNOTATIONS_LIST_WARNING =
-      "Received image annotation response without text annotations.";
-  private static final String IMAGE_REQUEST_FAILED_WARNING = "Image annotation request failed.";
-  private static final String TEXT_REQUEST_FAILED_WARNING = "Classify text request failed.";
-
   private static final ByteString IMAGE_BYTES = ByteString.copyFromUtf8("byte string");
-  private static final String RAW_TEXT = "raw text";
+  private static final Optional<String> RAW_TEXT = Optional.of("raw text");
 
   private static final String GENERAL_CATEGORY_NAME = "General";
   private static final String BROADER_CATEGORY_NAME = "Broader";
@@ -127,7 +118,7 @@ public final class ReceiptAnalysisTest {
   @Test
   public void analyzeImageAtUrlReturnsAnalysisResults()
       throws IOException, ReceiptAnalysisException {
-    stubAnnotationResponse(LOGO_CONFIDENCE, RAW_TEXT);
+    stubAnnotationResponse(LOGO_CONFIDENCE, RAW_TEXT.get());
     stubTextClassification();
     ImmutableList<AnnotateImageRequest> imageRequests = createImageRequest();
     ClassifyTextRequest classifyRequest = createClassifyRequest();
@@ -144,7 +135,7 @@ public final class ReceiptAnalysisTest {
   @Test
   public void analyzeImageAtUrlReturnsAnalysisResultsWithNoStore()
       throws IOException, ReceiptAnalysisException {
-    AnnotateImageResponse imageResponse = createImageResponseWithText(RAW_TEXT).build();
+    AnnotateImageResponse imageResponse = createImageResponseWithText(RAW_TEXT.get()).build();
     BatchAnnotateImagesResponse batchResponse =
         BatchAnnotateImagesResponse.newBuilder().addResponses(imageResponse).build();
     when(imageClient.batchAnnotateImages(anyList())).thenReturn(batchResponse);
@@ -159,7 +150,7 @@ public final class ReceiptAnalysisTest {
   @Test
   public void analyzeImageAtUrlIgnoresLogoIfLowConfidence()
       throws IOException, ReceiptAnalysisException {
-    stubAnnotationResponse(LOGO_CONFIDENCE_BELOW_THRESHOLD, RAW_TEXT);
+    stubAnnotationResponse(LOGO_CONFIDENCE_BELOW_THRESHOLD, RAW_TEXT.get());
     stubTextClassification();
     ImmutableList<AnnotateImageRequest> imageRequests = createImageRequest();
     ClassifyTextRequest classifyRequest = createClassifyRequest();
@@ -223,19 +214,20 @@ public final class ReceiptAnalysisTest {
   }
 
   @Test
-  public void analyzeImageAtThrowsIfEmptyBatchResponse()
+  public void analyzeImageAt_emptyBatchResponse_returnsEmptyAnalysisResults()
       throws IOException, ReceiptAnalysisException {
     BatchAnnotateImagesResponse batchResponse = BatchAnnotateImagesResponse.newBuilder().build();
     when(imageClient.batchAnnotateImages(anyList())).thenReturn(batchResponse);
 
-    ReceiptAnalysisException exception = Assertions.assertThrows(
-        ReceiptAnalysisException.class, () -> { ReceiptAnalysis.analyzeImageAt(url); });
+    AnalysisResults results = ReceiptAnalysis.analyzeImageAt(url);
 
-    Assert.assertEquals(EMPTY_BATCH_RESPONSE_WARNING, exception.getMessage());
+    Assert.assertEquals(Optional.empty(), results.getRawText());
+    Assert.assertEquals(ImmutableSet.of(), results.getCategories());
+    Assert.assertEquals(Optional.empty(), results.getStore());
   }
 
   @Test
-  public void analyzeImageAtThrowsIfResponseHasError()
+  public void analyzeImageAt_responseError_returnsEmptyAnalysisResults()
       throws IOException, ReceiptAnalysisException {
     AnnotateImageResponse response =
         AnnotateImageResponse.newBuilder().setError(Status.getDefaultInstance()).build();
@@ -243,44 +235,65 @@ public final class ReceiptAnalysisTest {
         BatchAnnotateImagesResponse.newBuilder().addResponses(response).build();
     when(imageClient.batchAnnotateImages(anyList())).thenReturn(batchResponse);
 
-    ReceiptAnalysisException exception = Assertions.assertThrows(
-        ReceiptAnalysisException.class, () -> { ReceiptAnalysis.analyzeImageAt(url); });
+    AnalysisResults results = ReceiptAnalysis.analyzeImageAt(url);
 
-    Assert.assertEquals(RESPONSE_ERROR_WARNING, exception.getMessage());
+    Assert.assertEquals(Optional.empty(), results.getRawText());
+    Assert.assertEquals(ImmutableSet.of(), results.getCategories());
+    Assert.assertEquals(Optional.empty(), results.getStore());
   }
 
   @Test
-  public void analyzeImageAtThrowsIfEmptyTextAnnotationsList()
+  public void analyzeImageAt_emptyTextAnnotationsListWithoutLogo_returnsEmptyAnalysisResults()
       throws IOException, ReceiptAnalysisException {
     AnnotateImageResponse response = AnnotateImageResponse.newBuilder().build();
     BatchAnnotateImagesResponse batchResponse =
         BatchAnnotateImagesResponse.newBuilder().addResponses(response).build();
     when(imageClient.batchAnnotateImages(anyList())).thenReturn(batchResponse);
 
-    ReceiptAnalysisException exception = Assertions.assertThrows(
-        ReceiptAnalysisException.class, () -> { ReceiptAnalysis.analyzeImageAt(url); });
+    AnalysisResults results = ReceiptAnalysis.analyzeImageAt(url);
 
-    Assert.assertEquals(EMPTY_TEXT_ANNOTATIONS_LIST_WARNING, exception.getMessage());
+    Assert.assertEquals(Optional.empty(), results.getRawText());
+    Assert.assertEquals(ImmutableSet.of(), results.getCategories());
+    Assert.assertEquals(Optional.empty(), results.getStore());
   }
 
   @Test
-  public void analyzeImageAtThrowsIfImageRequestFails()
+  public void analyzeImageAt_emptyTextAnnotationsListWithLogo_setsLogoOnly()
+      throws IOException, ReceiptAnalysisException {
+    EntityAnnotation logoAnnotation =
+        EntityAnnotation.newBuilder().setDescription(STORE.get()).setScore(LOGO_CONFIDENCE).build();
+    AnnotateImageResponse response =
+        AnnotateImageResponse.newBuilder().addLogoAnnotations(logoAnnotation).build();
+    BatchAnnotateImagesResponse batchResponse =
+        BatchAnnotateImagesResponse.newBuilder().addResponses(response).build();
+    when(imageClient.batchAnnotateImages(anyList())).thenReturn(batchResponse);
+
+    AnalysisResults results = ReceiptAnalysis.analyzeImageAt(url);
+
+    Assert.assertEquals(Optional.empty(), results.getRawText());
+    Assert.assertEquals(ImmutableSet.of(), results.getCategories());
+    Assert.assertEquals(STORE, results.getStore());
+  }
+
+  @Test
+  public void analyzeImageAt_imageRequestFailure_returnsEmptyAnalysisResults()
       throws IOException, ReceiptAnalysisException {
     StatusCode statusCode = GrpcStatusCode.of(io.grpc.Status.INTERNAL.getCode());
     ApiException clientException = new ApiException(null, statusCode, false);
     when(imageClient.batchAnnotateImages(anyList())).thenThrow(clientException);
 
-    ReceiptAnalysisException exception = Assertions.assertThrows(
-        ReceiptAnalysisException.class, () -> { ReceiptAnalysis.analyzeImageAt(url); });
+    AnalysisResults results = ReceiptAnalysis.analyzeImageAt(url);
 
-    Assert.assertEquals(IMAGE_REQUEST_FAILED_WARNING, exception.getMessage());
-    Assert.assertEquals(clientException, exception.getCause());
+    Assert.assertEquals(Optional.empty(), results.getRawText());
+    Assert.assertEquals(ImmutableSet.of(), results.getCategories());
+    Assert.assertEquals(Optional.empty(), results.getStore());
   }
 
   @Test
-  public void analyzeImageAtThrowsIfTextRequestFails()
+  public void analyzeImageAt_textRequestFailure_returnsEmptyCategories()
       throws IOException, ReceiptAnalysisException {
-    EntityAnnotation annotation = EntityAnnotation.newBuilder().setDescription(RAW_TEXT).build();
+    EntityAnnotation annotation =
+        EntityAnnotation.newBuilder().setDescription(RAW_TEXT.get()).build();
     AnnotateImageResponse imageResponse =
         AnnotateImageResponse.newBuilder().addTextAnnotations(annotation).build();
     BatchAnnotateImagesResponse batchResponse =
@@ -291,11 +304,9 @@ public final class ReceiptAnalysisTest {
     ApiException clientException = new ApiException(null, statusCode, false);
     when(languageClient.classifyText(any(ClassifyTextRequest.class))).thenThrow(clientException);
 
-    ReceiptAnalysisException exception = Assertions.assertThrows(
-        ReceiptAnalysisException.class, () -> { ReceiptAnalysis.analyzeImageAt(url); });
+    AnalysisResults results = ReceiptAnalysis.analyzeImageAt(url);
 
-    Assert.assertEquals(TEXT_REQUEST_FAILED_WARNING, exception.getMessage());
-    Assert.assertEquals(clientException, exception.getCause());
+    Assert.assertEquals(ImmutableSet.of(), results.getCategories());
   }
 
   private void stubAnnotationResponse(float confidenceScore, String rawText) {
@@ -332,7 +343,8 @@ public final class ReceiptAnalysisTest {
   }
 
   private ClassifyTextRequest createClassifyRequest() {
-    Document document = Document.newBuilder().setContent(RAW_TEXT).setType(Type.PLAIN_TEXT).build();
+    Document document =
+        Document.newBuilder().setContent(RAW_TEXT.get()).setType(Type.PLAIN_TEXT).build();
     return ClassifyTextRequest.newBuilder().setDocument(document).build();
   }
 }

--- a/src/test/java/UploadReceiptServletTest.java
+++ b/src/test/java/UploadReceiptServletTest.java
@@ -113,12 +113,12 @@ public final class UploadReceiptServletTest {
   private static final Text RAW_TEXT = new Text("raw text");
   private static final double PRICE = 5.89;
   private static final String STORE = "mcdonald's";
-  private static final AnalysisResults ANALYSIS_RESULTS =
-      new AnalysisResults.Builder(RAW_TEXT.getValue())
-          .setCategories(GENERATED_CATEGORIES)
-          .setTimestamp(PAST_TIMESTAMP)
-          .setStore(STORE)
-          .build();
+  private static final AnalysisResults ANALYSIS_RESULTS = new AnalysisResults.Builder()
+                                                              .setRawText(RAW_TEXT.getValue())
+                                                              .setCategories(GENERATED_CATEGORIES)
+                                                              .setTimestamp(PAST_TIMESTAMP)
+                                                              .setStore(STORE)
+                                                              .build();
 
   private static final String IMAGE_URL = "/serve-image?blob-key=" + BLOB_KEY.getKeyString();
   private static final String LIVE_SERVER_BASE_URL =
@@ -265,7 +265,8 @@ public final class UploadReceiptServletTest {
 
     // Mock receipt analysis.
     String store = "    TraDeR   JOE's  ";
-    AnalysisResults analysisResults = new AnalysisResults.Builder(RAW_TEXT.getValue())
+    AnalysisResults analysisResults = new AnalysisResults.Builder()
+                                          .setRawText(RAW_TEXT.getValue())
                                           .setCategories(GENERATED_CATEGORIES)
                                           .setTimestamp(PAST_TIMESTAMP)
                                           .setStore(store)
@@ -294,7 +295,8 @@ public final class UploadReceiptServletTest {
         request, LIVE_SERVER_SCHEME, LIVE_SERVER_NAME, LIVE_SERVER_PORT, LIVE_SERVER_CONTEXT_PATH);
 
     // Mock receipt analysis.
-    AnalysisResults analysisResults = new AnalysisResults.Builder(RAW_TEXT.getValue())
+    AnalysisResults analysisResults = new AnalysisResults.Builder()
+                                          .setRawText(RAW_TEXT.getValue())
                                           .setCategories(GENERATED_CATEGORIES)
                                           .setTimestamp(PAST_TIMESTAMP)
                                           .build();
@@ -321,7 +323,8 @@ public final class UploadReceiptServletTest {
     // Mock receipt analysis.
     Set<String> generatedCategories =
         ImmutableSet.of("   fast   Food ", " Burger ", "  rEstaUrAnt ", "    LUNCH", "  dIninG ");
-    AnalysisResults analysisResults = new AnalysisResults.Builder(RAW_TEXT.getValue())
+    AnalysisResults analysisResults = new AnalysisResults.Builder()
+                                          .setRawText(RAW_TEXT.getValue())
                                           .setCategories(generatedCategories)
                                           .setTimestamp(PAST_TIMESTAMP)
                                           .setStore(STORE)
@@ -402,7 +405,8 @@ public final class UploadReceiptServletTest {
 
     // Mock receipt analysis.
     long futureTimestamp = Instant.parse(INSTANT).plusMillis(1234).toEpochMilli();
-    AnalysisResults analysisResults = new AnalysisResults.Builder(RAW_TEXT.getValue())
+    AnalysisResults analysisResults = new AnalysisResults.Builder()
+                                          .setRawText(RAW_TEXT.getValue())
                                           .setCategories(GENERATED_CATEGORIES)
                                           .setTimestamp(futureTimestamp)
                                           .setStore(STORE)


### PR DESCRIPTION
Previously, any error that occurred during the receipt analysis, such as with extracting raw text, detecting the store name, or generating categories, would prevent the user from uploading a receipt.
- Makes the raw text field optional for the `AnalysisResults` class
- Instead of throwing receipt analysis exceptions, return `AnalysisResults` with empty fields, so that the user can manually input them (ex. If no raw text can be extracted from an image, upload a receipt with empty raw text and category fields)