### PR TITLE
Increase logo detection confidence score threshold.

### DIFF
--- a/src/main/java/servlets/ReceiptAnalysis.java
+++ b/src/main/java/servlets/ReceiptAnalysis.java
@@ -60,7 +60,7 @@ public class ReceiptAnalysis {
   // is in identifying the detected logo, with higher scores meaning higher certainty. This is the
   // minimum confidence score that a detected logo must have to be considered significant for
   // receipt analysis.
-  private static final float LOGO_DETECTION_CONFIDENCE_THRESHOLD = 0.4f;
+  private static final float LOGO_DETECTION_CONFIDENCE_THRESHOLD = 0.6f;
   // Matches strings containing at least one digit.
   private static final Pattern digitRegex = Pattern.compile(".*\\d.*");
   // Matches strings in U.S. date format.

--- a/src/test/java/ReceiptAnalysisTest.java
+++ b/src/test/java/ReceiptAnalysisTest.java
@@ -88,7 +88,7 @@ public final class ReceiptAnalysisTest {
       ImmutableSet.of(GENERAL_CATEGORY_NAME, BROADER_CATEGORY_NAME, SPECIFIC_CATEGORY_NAME);
 
   private static final Optional<String> STORE = Optional.of("Google");
-  private static final float LOGO_CONFIDENCE = 0.6f;
+  private static final float LOGO_CONFIDENCE = 0.8f;
   private static final float LOGO_CONFIDENCE_BELOW_THRESHOLD = 0.2f;
 
   private static final String RAW_TEXT_WITH_DATE = "the date is 05-08-2020";


### PR DESCRIPTION
Raised threshold from 40% to 60% based on testing with sample receipts in order to favor a greater accuracy.