### PR TITLE
Fix custom date range selection.

### DIFF
--- a/src/main/webapp/js/index.js
+++ b/src/main/webapp/js/index.js
@@ -217,6 +217,8 @@ $(function() {
               ],
             },
             showDropdowns: true,
+            linkedCalendars: false,
+            applyButtonClasses: 'btn btn-info',
           },
 
           cb);


### PR DESCRIPTION
- Unlinks the calendars for a custom date range, meaning the two calendars can be individually advanced and display any month/year
- Makes the "Apply" button for a custom date range have the same style as the other buttons

![home](https://user-images.githubusercontent.com/38800607/89235552-5f708900-d5bc-11ea-984e-15cf82366b33.png)