### PR TITLE
Prevent "subtotal" from counting as a total token

### DIFF
--- a/src/main/java/servlets/ReceiptAnalysis.java
+++ b/src/main/java/servlets/ReceiptAnalysis.java
@@ -68,6 +68,8 @@ public class ReceiptAnalysis {
   private static final Pattern priceRegex = Pattern.compile("\\$?\\d+\\.\\d\\d");
   // Matches strings containing the word "total" with any capitalization.
   private static final Pattern totalRegex = Pattern.compile(".*total.*", Pattern.CASE_INSENSITIVE);
+  // Matches strings containing the word "sub" with any capitalization.
+  private static final Pattern subRegex = Pattern.compile(".*sub.*", Pattern.CASE_INSENSITIVE);
 
   /** Returns the text and categorization of the image at the requested URL. */
   public static AnalysisResults analyzeImageAt(URL url) throws IOException {
@@ -369,10 +371,10 @@ public class ReceiptAnalysis {
   }
 
   /**
-   * Checks if the token contains the word "total".
+   * Checks if the token contains "total" and doesn't contain "sub".
    */
   private static boolean containsTotal(String token) {
-    return totalRegex.matcher(token).matches();
+    return totalRegex.matcher(token).matches() && !subRegex.matcher(token).matches();
   }
 
   public static class ReceiptAnalysisException extends Exception {

--- a/src/test/java/ReceiptAnalysisTest.java
+++ b/src/test/java/ReceiptAnalysisTest.java
@@ -294,6 +294,18 @@ public final class ReceiptAnalysisTest {
   }
 
   @Test
+  public void analyzeImageAt_subtotalToken_returnsLargestPrice()
+      throws IOException, ReceiptAnalysisException {
+    String rawTextWithPriceSubtotal = "the subtotal is $12.23 and the balance is $" + PRICE_VALUE;
+    stubAnnotationResponse(LOGO_CONFIDENCE, rawTextWithPriceSubtotal);
+    stubTextClassification();
+
+    AnalysisResults results = ReceiptAnalysis.analyzeImageAt(url);
+
+    Assert.assertEquals(PRICE, results.getPrice());
+  }
+
+  @Test
   public void analyzeImageAt_lastTotalHasNoPrice_returnsPriceAfterOtherTotal()
       throws IOException, ReceiptAnalysisException {
     String rawTextWithPriceExtraTotal =


### PR DESCRIPTION
This should help handle cases like the Bed Bath & Beyond receipt that have "subtotal" but not "total".